### PR TITLE
feat: Chacha20Poly1035 JWE - Authcrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ standard where possible. The Godoc reference has a list of constants.
  ECDH-ES + AES key wrap     | ECDH-ES+A128KW, ECDH-ES+A192KW, ECDH-ES+A256KW
  ECDH-ES (direct)           | ECDH-ES<sup>1</sup>
  Direct encryption          | dir<sup>1</sup>
+ ECDH-ES+(X)Chaha20+Poly1035| ECDH-ES+C20PKW, ECDH-ES+XC20PKW
 
 <sup>1. Not supported in multi-recipient mode</sup>
 
@@ -89,6 +90,7 @@ standard where possible. The Godoc reference has a list of constants.
  :------------------------- | :------------------------------
  AES-CBC+HMAC               | A128CBC-HS256, A192CBC-HS384, A256CBC-HS512
  AES-GCM                    | A128GCM, A192GCM, A256GCM 
+ (X)CHACHA20+Poly1035       | C20P, XC20P
 
  Compression                | Algorithm identifiers(s)
  :------------------------- | -------------------------------

--- a/crypter.go
+++ b/crypter.go
@@ -445,6 +445,9 @@ func (obj JSONWebEncryption) Decrypt(decryptionKey interface{}) ([]byte, error) 
 	if err == nil {
 		// Found a valid CEK -- let's try to decrypt.
 		plaintext, err = cipher.decrypt(cek, authData, parts)
+		if err != nil {
+			println("square/go-jose [WARN]: error decrypting cipher:" + err.Error())
+		}
 	}
 
 	if plaintext == nil {

--- a/crypter_test.go
+++ b/crypter_test.go
@@ -99,8 +99,13 @@ func TestRoundtripsJWE(t *testing.T) {
 		DIRECT, ECDH_ES, ECDH_ES_A128KW, ECDH_ES_A192KW, ECDH_ES_A256KW, A128KW, A192KW, A256KW,
 		RSA1_5, RSA_OAEP, RSA_OAEP_256, A128GCMKW, A192GCMKW, A256GCMKW,
 		PBES2_HS256_A128KW, PBES2_HS384_A192KW, PBES2_HS512_A256KW,
+		ECDH_ES_C20PKW,
+		ECDH_ES_XC20PKW,
 	}
-	encAlgs := []ContentEncryption{A128GCM, A192GCM, A256GCM, A128CBC_HS256, A192CBC_HS384, A256CBC_HS512}
+	encAlgs := []ContentEncryption{
+		A128GCM, A192GCM, A256GCM, A128CBC_HS256, A192CBC_HS384, A256CBC_HS512,
+		C20P, XC20P,
+	}
 	zipAlgs := []CompressionAlgorithm{NONE, DEFLATE}
 
 	serializers := []func(*JSONWebEncryption) (string, error){
@@ -677,7 +682,7 @@ func generateTestKeys(keyAlg KeyAlgorithm, encAlg ContentEncryption) []testKey {
 		return symmetricTestKey(16)
 	case A192GCMKW, A192KW:
 		return symmetricTestKey(24)
-	case A256GCMKW, A256KW:
+	case A256GCMKW, A256KW, ECDH_ES_C20PKW, ECDH_ES_XC20PKW:
 		return symmetricTestKey(32)
 	case RSA1_5, RSA_OAEP, RSA_OAEP_256:
 		return []testKey{{

--- a/go.sum
+++ b/go.sum
@@ -10,5 +10,6 @@ golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f h1:R423Cnkcp5JABoeemiGEPl
 golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/jwe_test.go
+++ b/jwe_test.go
@@ -25,6 +25,8 @@ import (
 	"math/big"
 	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCompactParseJWE(t *testing.T) {
@@ -72,6 +74,8 @@ func TestFullParseJWE(t *testing.T) {
 		"{\"protected\":\"eyJhbGciOiJYWVoiLCJlbmMiOiJYWVoifQo\",\"encrypted_key\":\"QUJD\",\"iv\":\"QUJD\",\"ciphertext\":\"QUJD\",\"tag\":\"QUJD\"}",
 		// Unflattened serialization, single recipient
 		"{\"protected\":\"\",\"unprotected\":{\"enc\":\"XYZ\"},\"recipients\":[{\"header\":{\"alg\":\"XYZ\"},\"encrypted_key\":\"QUJD\"}],\"iv\":\"QUJD\",\"ciphertext\":\"QUJD\",\"tag\":\"QUJD\"}",
+		// multiple recipients using Chacha20Poly1035
+		"{\"protected\":\"eyJ0eXAiOiJwcnMuaHlwZXJsZWRnZXIuYXJpZXMtYXV0aC1tZXNzYWdlIiwiYWxnIjoiRUNESCtYQzIwUEtXIiwiZW5jIjoiWEMyMFAifQ\",\"recipients\":[{\"encrypted_key\": \"whpkJkvHRP0XX-EqxUOHhHIfuW8i5EMuR3Kxlg5NNIU\",\"header\": {    \"kid\": \"5jMonJACEPcLfqVaz8jpqBLXHHKYgCE71XYBmFXhjZVX\",    \"iv\": \"tjGLK6uChZatAyACFzGmFR4V9othKN8S\",    \"tag\": \"ma9pIjkQuzaqvq_5y5vUlQ\",    \"pk\": \"eyJpdiI6IldoVGptNi1DX2xiTlQ4Q2RzN2dfNjdMZzZKSEF3NU5BIiwiZXBrIjp7Imt0eSI6Ik9LUCIsImNydiI6IlgyNTUxOSIsIngiOiJnNjRfblJSSFQyYk1JX1hjT1dHRTdJOGdQcU1VWTF4aUNub2J0LVhDUkNZIn0sInR5cCI6Impvc2UiLCJjdHkiOiJqd2sranNvbiIsImFsZyI6IkVDREgtRVMrWEMyMFBLVyIsImVuYyI6IlhDMjBQIn0.4zUt5tOOlcQWskJqxfMi0tNsfUCAzb5_PDfPqQ1h0Vw.xYkeEXV1_cSYFEd6UBMIfl8MWQfHaDex.XSNKTRXye5-iSXQ-aS_vQVZNEgFE6iA9X_KgSRMzihQBMoI1j4WM3o-9dMT9TeSyMvdq3gXt1NpvLdZHpJplahhk3mxMZL-vawm5Prtf.H7a5N-dggwdesjHyJCl06w\"  }},{  \"encrypted_key\": \"dDHydlp_wlGt_zwR-yUvESx9fXuO-GRJFGtaw2u6CEw\",  \"header\": {    \"kid\": \"TfVVqzPT1FQHdq1CUDe9XYcg6Wu2QMusWKhGBXEZsosg\",    \"iv\": \"7SFlGTxQ4Q2l02D9HRNdFeYQnwntyctb\",    \"tag\": \"9-O6djpNAizix-ZnjAx-Fg\",    \"pk\": \"eyJpdiI6IkV6UjBFaVRLazJCT19oc05qOVRxeU9PVmVLRFFPYVp1IiwiZXBrIjp7Imt0eSI6Ik9LUCIsImNydiI6IlgyNTUxOSIsIngiOiJoU1g1NGt5ZTdsd0pBdjlMaUplTmh4eFhaV1N0M3hLSDBXUmh6T1NOb1c0In0sInR5cCI6Impvc2UiLCJjdHkiOiJqd2sranNvbiIsImFsZyI6IkVDREgtRVMrWEMyMFBLVyIsImVuYyI6IlhDMjBQIn0.qKmU5xO8Z1ZtRBWEjEMixb5VZG0mrY0LnjUGjLqktwg.EG-VOZSC2vLdoO5l2_A37IYvdXCckLZp.D4kgD6bYL1YfXyApk5ESKE2sc8TUiO-QGBtY-M5hcV_F88JPZdsi53Qofxk02ZxPHJZK-abDy45pIMH6-KUMDfE6WKhW3nPQhydPYutv.0SO4VjM8sDH-wGHcEpinTg\"  }}],\"aad\": \"OGY5ZDIxMDE3YTQ4MTc4YWE5MTk0MWQyOGJmYjQ1ZmZmMTYzYTE3ZjUxYjc4YjA3YTlmY2FlMmMwOTFlMjBhZg\",\"ciphertext\": \"x1lnQq_pZLgU2ZC4\",\"tag\": \"2JgOe9SRjJXddT9TyIjqrg\",\"iv\": \"fDGEXswlWXOBx6FxPC_u6qIuhADnOrW1\"}",
 	}
 
 	for i := range successes {
@@ -677,4 +681,33 @@ func TestJWEWithNullAlg(t *testing.T) {
 	if _, err := ParseEncrypted(serialized); err == nil {
 		t.Error(err)
 	}
+}
+
+func TestJWEWithChacha20PolyAlg(t *testing.T) {
+	// multiple recipients using Chacha20Poly1035
+	validJweCipher := "{\"protected\":\"eyJ0eXAiOiJwcnMuaHlwZXJsZWRnZXIuYXJpZXMtYXV0aC1tZXNzYWdlIiwiYWxnIjoiRUNESCtYQzIwUEtXIiwiZW5jIjoiWEMyMFAifQ\",\"recipients\":[{\"encrypted_key\": \"whpkJkvHRP0XX-EqxUOHhHIfuW8i5EMuR3Kxlg5NNIU\",\"header\": {    \"kid\": \"5jMonJACEPcLfqVaz8jpqBLXHHKYgCE71XYBmFXhjZVX\",    \"iv\": \"tjGLK6uChZatAyACFzGmFR4V9othKN8S\",    \"tag\": \"ma9pIjkQuzaqvq_5y5vUlQ\",    \"pk\": \"eyJpdiI6IldoVGptNi1DX2xiTlQ4Q2RzN2dfNjdMZzZKSEF3NU5BIiwiZXBrIjp7Imt0eSI6Ik9LUCIsImNydiI6IlgyNTUxOSIsIngiOiJnNjRfblJSSFQyYk1JX1hjT1dHRTdJOGdQcU1VWTF4aUNub2J0LVhDUkNZIn0sInR5cCI6Impvc2UiLCJjdHkiOiJqd2sranNvbiIsImFsZyI6IkVDREgtRVMrWEMyMFBLVyIsImVuYyI6IlhDMjBQIn0.4zUt5tOOlcQWskJqxfMi0tNsfUCAzb5_PDfPqQ1h0Vw.xYkeEXV1_cSYFEd6UBMIfl8MWQfHaDex.XSNKTRXye5-iSXQ-aS_vQVZNEgFE6iA9X_KgSRMzihQBMoI1j4WM3o-9dMT9TeSyMvdq3gXt1NpvLdZHpJplahhk3mxMZL-vawm5Prtf.H7a5N-dggwdesjHyJCl06w\"  }},{  \"encrypted_key\": \"dDHydlp_wlGt_zwR-yUvESx9fXuO-GRJFGtaw2u6CEw\",  \"header\": {    \"kid\": \"TfVVqzPT1FQHdq1CUDe9XYcg6Wu2QMusWKhGBXEZsosg\",    \"iv\": \"7SFlGTxQ4Q2l02D9HRNdFeYQnwntyctb\",    \"tag\": \"9-O6djpNAizix-ZnjAx-Fg\",    \"pk\": \"eyJpdiI6IkV6UjBFaVRLazJCT19oc05qOVRxeU9PVmVLRFFPYVp1IiwiZXBrIjp7Imt0eSI6Ik9LUCIsImNydiI6IlgyNTUxOSIsIngiOiJoU1g1NGt5ZTdsd0pBdjlMaUplTmh4eFhaV1N0M3hLSDBXUmh6T1NOb1c0In0sInR5cCI6Impvc2UiLCJjdHkiOiJqd2sranNvbiIsImFsZyI6IkVDREgtRVMrWEMyMFBLVyIsImVuYyI6IlhDMjBQIn0.qKmU5xO8Z1ZtRBWEjEMixb5VZG0mrY0LnjUGjLqktwg.EG-VOZSC2vLdoO5l2_A37IYvdXCckLZp.D4kgD6bYL1YfXyApk5ESKE2sc8TUiO-QGBtY-M5hcV_F88JPZdsi53Qofxk02ZxPHJZK-abDy45pIMH6-KUMDfE6WKhW3nPQhydPYutv.0SO4VjM8sDH-wGHcEpinTg\"  }}],\"aad\": \"OGY5ZDIxMDE3YTQ4MTc4YWE5MTk0MWQyOGJmYjQ1ZmZmMTYzYTE3ZjUxYjc4YjA3YTlmY2FlMmMwOTFlMjBhZg\",\"ciphertext\": \"x1lnQq_pZLgU2ZC4\",\"tag\": \"2JgOe9SRjJXddT9TyIjqrg\",\"iv\": \"fDGEXswlWXOBx6FxPC_u6qIuhADnOrW1\"}"
+	jwe, err := ParseEncrypted(validJweCipher)
+	require.NoErrorf(t, err, "Able to parse invalid message", validJweCipher)
+	require.NotEmpty(t, jwe)
+
+	t.Logf("Number of recepients are: %d", len(jwe.recipients))
+	for i := range jwe.recipients {
+		h, e := jwe.recipients[i].header.sanitized()
+		require.NoError(t, e)
+		require.NotEmpty(t, h)
+		senderPk, err := getPK(jwe.recipients[i].header)
+		t.Logf("PK of recipient %d: %v", i+1, senderPk)
+		require.NoError(t, err)
+		require.NotEmpty(t, senderPk)
+		require.Equal(t, 1, len(senderPk.recipients))
+		require.Equal(t, string(ECDH_ES_XC20PKW), senderPk.Header.Algorithm)
+	}
+}
+
+func getPK(parsed *rawHeader) (*JSONWebEncryption, error) {
+	pk, err := parseEncryptedCompact(parsed.getString(headerPk))
+	if err != nil {
+		return nil, err
+	}
+	return pk, nil
 }

--- a/shared.go
+++ b/shared.go
@@ -93,6 +93,8 @@ const (
 	PBES2_HS256_A128KW = KeyAlgorithm("PBES2-HS256+A128KW") // PBES2 + HMAC-SHA256 + AES key wrap (128)
 	PBES2_HS384_A192KW = KeyAlgorithm("PBES2-HS384+A192KW") // PBES2 + HMAC-SHA384 + AES key wrap (192)
 	PBES2_HS512_A256KW = KeyAlgorithm("PBES2-HS512+A256KW") // PBES2 + HMAC-SHA512 + AES key wrap (256)
+	ECDH_ES_C20PKW     = KeyAlgorithm("ECDH-ES+C20PKW")     // ECDH-ES + Chacha20-Poly1035 key wrap (key header with sender signature using 96 bits nonce)
+	ECDH_ES_XC20PKW    = KeyAlgorithm("ECDH-ES+XC20PKW")    // ECDH-ES + XChacha20-Poly1035 key wrap (key header with sender signature using 192 bits nonce)
 )
 
 // Signature algorithms
@@ -120,6 +122,8 @@ const (
 	A128GCM       = ContentEncryption("A128GCM")       // AES-GCM (128)
 	A192GCM       = ContentEncryption("A192GCM")       // AES-GCM (192)
 	A256GCM       = ContentEncryption("A256GCM")       // AES-GCM (256)
+	C20P          = ContentEncryption("C20P")          // ChaCha20 stream cipher + Poly1305 authenticator (96 bits nonce)
+	XC20P         = ContentEncryption("XC20P")         // ChaCha20 stream cipher + Poly1305 authenticator (192 bits nonce)
 )
 
 // Compression algorithms
@@ -157,6 +161,11 @@ const (
 
 	headerP2C = "p2c" // *byteBuffer (int)
 	headerP2S = "p2s" // *byteBuffer ([]byte)
+
+	// sender pk represented as a compact JWE used for AuthCrypt sender encrypted key.
+	// For AnonCrypt key, pk will be empty and the encrypted cek will be included in epk header.
+	// This header check logic must be included in jwe sanitization.
+	headerPk = "pk" // compact *JSONWebEncryption
 
 )
 


### PR DESCRIPTION
This PR incorporates Chacha20 and it's sibling XChacha20 stream cipher along with Poly1035 authenticator in JWE.

This change to the library (and the JWE spec) is needed for the Hyperledger Aries project as per this issue:
https://github.com/hyperledger/aries-rfcs/issues/133

There are discussions to update the JWE spec as mentioned in the above-mentioned issue.

Signed-off-by: Baha Shaaban <baha.shaaban@securekey.com>